### PR TITLE
Inject container in migration files

### DIFF
--- a/Migrator/Migrator.php
+++ b/Migrator/Migrator.php
@@ -11,6 +11,8 @@
 
 namespace Claroline\MigrationBundle\Migrator;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\Migration;
@@ -29,16 +31,19 @@ class Migrator
     const DIRECTION_DOWN = 'down';
 
     private $connection;
+    private $container;
     private $cacheConfigs = array();
 
     /**
      * Constructor.
      *
      * @param \Doctrine\DBAL\Connection $connection
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      */
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, ContainerInterface $container)
     {
         $this->connection = $connection;
+        $this->container = $container;
     }
 
     /**
@@ -125,8 +130,8 @@ class Migrator
             }
 
             return $nearestVersion === false ? array() : $migration->migrate($nearestVersion);
-        } elseif(!is_numeric($version)) {
-          throw new InvalidVersionException($version);
+        } elseif (!is_numeric($version)) {
+            throw new InvalidVersionException($version);
         } elseif ($version > $currentVersion && $direction === self::DIRECTION_DOWN
             || $version < $currentVersion && $direction === self::DIRECTION_UP) {
             throw new InvalidDirectionException($direction);
@@ -160,6 +165,24 @@ class Migrator
 
         $this->cacheConfigs[$bundle->getName()] = $config;
 
+        $this->injectContainerToMigrations($this->container, $config->getMigrations());
+
         return $config;
+    }
+
+    /**
+     * @param ContainerInterface $container
+     * @param array $versions
+     *
+     * Injects the container to migrations aware of it
+     */
+    private function injectContainerToMigrations(ContainerInterface $container, array $versions)
+    {
+        foreach ($versions as $version) {
+            $migration = $version->getMigration();
+            if ($migration instanceof ContainerAwareInterface) {
+                $migration->setContainer($container);
+            }
+        }
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -29,6 +29,7 @@
         </service>
         <service id="claroline.migration.migrator" class="%claroline.migration_migrator.class%">
             <argument type="service" id="doctrine.dbal.default_connection" />
+            <argument type="service" id="service_container" />
         </service>
         <service id="claroline.migration.doctrine_schema_tool" class="%claroline.migration_schema_tool.class%">
             <argument type="service" id="doctrine.orm.entity_manager" />


### PR DESCRIPTION
# Description

Inject the service container in the migration files, as Doctrine have done:
http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html#container-aware-migrations

Reference: https://github.com/claroline/MigrationBundle/issues/14